### PR TITLE
Use more generic workflow slug in Python client example

### DIFF
--- a/python/example/client/main.py
+++ b/python/example/client/main.py
@@ -31,7 +31,7 @@ async def main():
     client = Client(token)
 
     # Example task data - replace with your actual task
-    task_identifier = "package-renaming-slug/square"  # Replace with your task name
+    task_identifier = "my-workflow-slug/square"  # Replace with your task identifier
     input_data: list[Any] = [3]
 
     # Run the task


### PR DESCRIPTION
- While my workflow has the `package-renaming` slug, let's use a more generic one in the example